### PR TITLE
Fixed formatting of the value 0

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -35,6 +35,9 @@ impl Base {
         F: Into<f64>,
     {
         let x: f64 = x.into();
+        if x == 0.0 {
+            return 0;
+        }
         match self {
             Self::B1000 => (x.abs().log10() / 3f64).floor() as i32 * 3,
             Self::B1024 => (x.abs().log2() / 10f64).floor() as i32 * 3,
@@ -59,5 +62,19 @@ impl Base {
             Self::B1000 => 1000f64.powf(exponent as f64 / 3f64),
             Self::B1024 => 1024f64.powf(exponent as f64 / 3f64),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exponent_of_zero_is_zero() {
+        assert_eq!(0, Base::B1000.integral_exponent_for(0.0));
+        assert_eq!(0, Base::B1000.integral_exponent_for(-0.0));
+        
+        assert_eq!(0, Base::B1024.integral_exponent_for(0.0));
+        assert_eq!(0, Base::B1024.integral_exponent_for(-0.0));
     }
 }

--- a/src/base.rs
+++ b/src/base.rs
@@ -73,7 +73,7 @@ mod tests {
     fn exponent_of_zero_is_zero() {
         assert_eq!(0, Base::B1000.integral_exponent_for(0.0));
         assert_eq!(0, Base::B1000.integral_exponent_for(-0.0));
-        
+
         assert_eq!(0, Base::B1024.integral_exponent_for(0.0));
         assert_eq!(0, Base::B1024.integral_exponent_for(-0.0));
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -242,6 +242,21 @@ mod tests {
         let expected = ".123_456_7--";
         assert_eq!(actual, expected);
     }
+
+    #[test]
+    fn format_zero_value() {
+        let x = 0.0f32;
+        let v: Value = x.into();
+        let unit = "F"; // just something displayable.
+
+        let actual = format!("result is {}{u}", format_value!(v, "{:>8.2}"), u = unit);
+        let expected = "result is     0.00 F";
+        assert_eq!(actual, expected);
+
+        let actual = format!("result is {}{u}", format_value!(v, "{:<8.3}"), u = unit);
+        let expected = "result is 0.000    F";
+        assert_eq!(actual, expected);
+    }
 }
 
 // macro_rules! format_scale {


### PR DESCRIPTION
As the title says, this PR fixes formatting of the value `0`. 

_The problem:_ When trying to format a value that is zero, the `Base::integral_exponent_for` gives the wrong result, because it uses `log10`/ `log2` but the logarithm of zero returns `-Inf`. In a debug build, this panics because of integer overflow, in a release build it just gives the wrong result. 

_What I did to fix it:_ I added a check for the zero-case to `Base::integral_exponent_for` to have it return `0`. I also added some tests that verify both this function and that formatting a zero `Value` give the correct results.

I hope you don't mind this PR, it seemed easy to fix but maybe this is not inline with how the library should be used? I really like this library and I'm trying to use it for progress logging in a tool that processes a large amount of data, but progress does start at zero, which is where I stumbled upon the bug. 