### PR TITLE
Fix a macro hygiene bug in scale_fn

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -66,8 +66,6 @@
 //! assert_eq!(actual, expected);
 //! ```
 
-use crate::value::Value;
-
 #[macro_export]
 macro_rules! scale_fn {
     (
@@ -106,7 +104,7 @@ macro_rules! scale_fn {
         where
             F: Into<f64>,
         {
-            let value = Value::new_with(
+            let value = $crate::value::Value::new_with(
                 x,
                 $crate::base::Base::$base_arg,
                 $crate::prefix::Constraint::$constraint_arg,
@@ -130,7 +128,7 @@ macro_rules! scale_fn {
         where
             F: Into<f64>,
         {
-            let value = Value::new_with(
+            let value = $crate::value::Value::new_with(
                 x,
                 $crate::base::Base::$base_arg,
                 $crate::prefix::Constraint::$constraint_arg,


### PR DESCRIPTION
This allows scale_fn to be used in external crates with groupings
defined.