### PR TITLE
Allow lossy conversions

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -33,22 +33,24 @@ jobs:
         continue-on-error: false
         with:
           path: |
-             ~/.cargo/bin/
-             ~/.cargo/registry/index/
-             ~/.cargo/registry/cache/
-             ~/.cargo/git/db/
-             target/
-          key: '${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles(''**/Cargo.lock'') }}'
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Lint
+      - name: Quality - cargo fmt
         run: |
           cargo fmt --all -- --check
-          cargo clippy -- -D warnings
+
+      - name: Quality - cargo clippy
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Quality - convco check
         run: |
           git show-ref
-          echo Commit message: "$(git log -1 --pretty=%B)"
           curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
           unzip convco-ubuntu.zip
           chmod +x convco
@@ -58,14 +60,18 @@ jobs:
 
       - name: Quality - cargo deny check
         run: |
-          curl -sSfL https://github.com/EmbarkStudios/cargo-deny/releases/download/0.16.1/cargo-deny-0.16.1-x86_64-unknown-linux-musl.tar.gz | tar zx --no-anchored cargo-deny --strip-components=1
+          VERSION=$(curl -s https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/latest | jq -r '.tag_name')
+          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
+            tar zx --no-anchored cargo-deny --strip-components=1
           chmod +x cargo-deny
           mv cargo-deny ~/.cargo/bin/
           cargo deny check
 
       - name: Quality - cargo audit check
         run: |
-          curl -sSfL https://github.com/rustsec/rustsec/releases/download/cargo-audit%2Fv0.17.3/cargo-audit-x86_64-unknown-linux-musl-v0.17.3.tgz | tar zx --no-anchored cargo-audit --strip-components=1
+          VERSION=$(curl -s https://api.github.com/repos/rustsec/rustsec/releases/latest | jq -r '.tag_name')
+          curl -sSfL "https://github.com/rustsec/rustsec/releases/download/${VERSION}/cargo-audit-x86_64-unknown-linux-musl-${VERSION#cargo-audit/}.tgz" | \
+            tar zx --no-anchored cargo-audit --strip-components=1
           chmod +x cargo-audit
           mv cargo-audit ~/.cargo/bin/
           rm -rf ~/.cargo/advisory-db/
@@ -74,7 +80,11 @@ jobs:
       - name: Quality - cargo outdated
         timeout-minutes: 20
         run: |
-          cargo install --locked cargo-outdated || true
+          VERSION=$(curl -s https://api.github.com/repos/kbknapp/cargo-outdated/releases/latest | jq -r '.tag_name')
+          curl -sSfL "https://github.com/kbknapp/cargo-outdated/releases/download/${VERSION}/cargo-outdated-${VERSION#v}-x86_64-unknown-linux-musl.tar.gz" | \
+            tar zx
+          chmod +x cargo-outdated
+          mv cargo-outdated ~/.cargo/bin/
           rm -rf ~/.cargo/advisory-db
           cargo outdated --exit-code 1
 

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -7,13 +7,12 @@ on:
       - staging
 
 jobs:
-  test_linux:
-    name: Test on Linux
+  test-versions:
+    name: Tests on Linux
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # rust: [1.74.0, beta, nightly]
-        rust: [1.74.0, beta]
+        rust: [1.74.0, beta, nightly]
 
     steps:
       - name: Rust install
@@ -30,59 +29,20 @@ jobs:
         continue-on-error: false
         with:
           path: |
-             ~/.cargo/bin/
-             ~/.cargo/registry/index/
-             ~/.cargo/registry/cache/
-             ~/.cargo/git/db/
-             target/
-          key: '${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles(''**/Cargo.lock'') }}'
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Lint
+      - name: Quality - cargo fmt
         run: |
           cargo fmt --all -- --check
-          cargo clippy -- -D warnings
 
-      # - name: Quality - convco check
-      #   run: |
-      #     git show-ref
-      #     curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
-      #     unzip convco-ubuntu.zip
-      #     chmod +x convco
-      #     ./convco --version
-      #     ./convco check -c .convco
-      #     rm convco
-
-      # - name: Quality - cargo deny check
-      #   run: |
-      #     curl -sSfL https://github.com/EmbarkStudios/cargo-deny/releases/download/0.12.2/cargo-deny-0.12.2-x86_64-unknown-linux-musl.tar.gz | tar zx --no-anchored cargo-deny --strip-components=1
-      #     chmod +x cargo-deny
-      #     mv cargo-deny ~/.cargo/bin/
-      #     cargo deny check
-
-      # - name: Quality - cargo audit check
-      #   run: |
-      #     curl -sSfL https://github.com/rustsec/rustsec/releases/download/cargo-audit%2Fv0.17.3/cargo-audit-x86_64-unknown-linux-musl-v0.17.3.tgz | tar zx --no-anchored cargo-audit --strip-components=1
-      #     chmod +x cargo-audit
-      #     mv cargo-audit ~/.cargo/bin/
-      #     rm -rf ~/.cargo/advisory-db/
-      #     cargo audit --ignore RUSTSEC-2020-0071 # time-rs, but not used by chrono, see https://github.com/chronotope/chrono/issues/602
-
-      # - name: Quality - cargo outdated
-      #   timeout-minutes: 20
-      #   run: |
-      #     cargo install --locked cargo-outdated || true
-      #     rm -rf ~/.cargo/advisory-db
-      #     cargo outdated --exit-code 1
-
-      # - name: Quality - cargo udeps (needs nightly)
-      #   run: |
-      #     cargo install --locked cargo-udeps || true
-      #     cargo udeps
-
-      # - name: Quality - cargo pants
-      #   run: |
-      #     cargo install --locked cargo-pants || true
-      #     cargo pants
+      - name: Quality - cargo clippy
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Build (dev)
         run: cargo build --all-features
@@ -94,13 +54,17 @@ jobs:
         run: ./ci/test_full.sh
 
   test-other-platforms:
-    name: Test on other platforms with stable
-    runs-on: '${{ matrix.os }}'
+    name: Tests on
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           - os: macos-13
             target: x86_64-apple-darwin
+            type: unix
+            toolchain: stable
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
             type: unix
             toolchain: stable
           - os: macos-latest
@@ -116,7 +80,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
           components: rustfmt, clippy
 
       - name: Checkout
@@ -127,62 +91,12 @@ jobs:
         continue-on-error: false
         with:
           path: |
-             ~/.cargo/bin/
-             ~/.cargo/registry/index/
-             ~/.cargo/registry/cache/
-             ~/.cargo/git/db/
-             target/
-          key: '${{ runner.os }}-${{ matrix.target }}-cargo-stable-${{ hashFiles(''**/Cargo.lock'') }}'
-
-      # - name: Quality - cargo fmt
-      #   run: |
-      #     cargo fmt --all -- --check
-
-      # - name: Quality - cargo clippy
-      #   run: |
-      #     cargo clippy -- -D warnings
-
-      # - name: Quality - convco check
-      #   run: |
-      #     git show-ref
-      #     curl -sSfLO https://github.com/convco/convco/releases/latest/download/convco-ubuntu.zip
-      #     unzip convco-ubuntu.zip
-      #     chmod +x convco
-      #     ./convco --version
-      #     ./convco check -c .convco
-      #     rm convco
-
-      # - name: Quality - cargo deny check
-      #   run: |
-      #     curl -sSfL https://github.com/EmbarkStudios/cargo-deny/releases/download/0.12.2/cargo-deny-0.12.2-x86_64-unknown-linux-musl.tar.gz | tar zx --no-anchored cargo-deny --strip-components=1
-      #     chmod +x cargo-deny
-      #     mv cargo-deny ~/.cargo/bin/
-      #     cargo deny check
-
-      # - name: Quality - cargo audit check
-      #   run: |
-      #     curl -sSfL https://github.com/rustsec/rustsec/releases/download/cargo-audit%2Fv0.17.3/cargo-audit-x86_64-unknown-linux-musl-v0.17.3.tgz | tar zx --no-anchored cargo-audit --strip-components=1
-      #     chmod +x cargo-audit
-      #     mv cargo-audit ~/.cargo/bin/
-      #     rm -rf ~/.cargo/advisory-db/
-      #     cargo audit --ignore RUSTSEC-2020-0071 # time-rs, but not used by chrono, see https://github.com/chronotope/chrono/issues/602
-
-      # - name: Quality - cargo outdated
-      #   timeout-minutes: 20
-      #   run: |
-      #     cargo install --locked cargo-outdated || true
-      #     rm -rf ~/.cargo/advisory-db
-      #     cargo outdated --exit-code 1
-
-      # - name: Quality - cargo udeps (needs nightly)
-      #   run: |
-      #     cargo install --locked cargo-udeps || true
-      #     cargo udeps
-
-      # - name: Quality - cargo pants
-      #   run: |
-      #     cargo install --locked cargo-pants || true
-      #     cargo pants
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-stable-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build (dev)
         run: cargo build --all-features

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.74.0, beta, nightly]
+        rust: [1.78.0, beta, nightly]
 
     steps:
       - name: Rust install

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             type: unix
             toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,10 @@ keywords = ["units", "pretty", "human", "number", "si-units"]
 categories = ["value-formatting", "science"]
 exclude = ["/.github"]
 
+[features]
+default = []
+## Enable `IntoF64` for `u64`, `i64`, `usize`, and `isize`.
+## These conversions may lose precision for values > 2^53.
+lossy-conversions = []
+
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Format values using the appropriate SI scale: seconds(1.3e-5) -> 
 readme = "README.md"
 
 license = "MIT OR Apache-2.0"
-authors = ["graelo <graelo@grael.cc>"]
+authors = ["graelo <graelo@graelo.cc>"]
 repository = "https://github.com/graelo/si-scale"
 homepage = "https://github.com/graelo/si-scale"
 documentation = "https://docs.rs/si-scale"

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![crate](https://img.shields.io/crates/v/si-scale.svg)](https://crates.io/crates/si-scale)
 [![documentation](https://docs.rs/si-scale/badge.svg)](https://docs.rs/si-scale)
-[![minimum rustc 1.74](https://img.shields.io/badge/rustc-1.74+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.78](https://img.shields.io/badge/rustc-1.78+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/graelo/si-scale/actions/workflows/essentials.yml/badge.svg)](https://github.com/graelo/si-scale/actions/workflows/essentials.yml)
 
 <!-- cargo-sync-readme start -->
 
 Format value with units according to SI ([système international d’unités](https://en.wikipedia.org/wiki/International_System_of_Units)).
 
-Version requirement: _rustc 1.74+_
+Version requirement: _rustc 1.78+_
 
 ```toml
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ It has the same purpose as the great
 
 - this crate yields more terse code at the call sites
 - it gives you more control over the output. As shown later in this page,
-you can extend it pretty easily to handle throughput, etc. (seriously, see
-below)
+  you can extend it pretty easily to handle throughput, etc. (seriously, see
+  below)
 - but it only operates on numbers, so it does not prevent you from using a
-function to print meters on a duration value (which human-repr does
-brilliantly).
+  function to print meters on a duration value (which human-repr does
+  brilliantly).
 
 ## Getting started
 
@@ -50,6 +50,16 @@ assert_eq!(actual, expected);
 let actual = format!("{}", seconds3(1.3e-5));
 let expected = "13.000 µs";
 assert_eq!(actual, expected);
+```
+
+## Features
+
+- **`lossy-conversions`**: enables support for `u64`, `i64`, `usize`, and
+  `isize`. These conversions may lose precision for values > 2^53.
+
+```toml
+[dependencies]
+si-scale = { version = "0.2", features = ["lossy-conversions"] }
 ```
 
 ## Pre-defined helper functions
@@ -219,7 +229,7 @@ which holds
 - the mantissa,
 - the SI unit prefix (such as "kilo", "Mega", etc),
 - and the base which represents the cases where "1 k" means 1000 (most
-common) and the cases where "1 k" means 1024 (for kiB, MiB, etc).
+  common) and the cases where "1 k" means 1024 (for kiB, MiB, etc).
 
 This crate provides 2 APIs: a low-level API, and a high-level API for
 convenience.
@@ -227,9 +237,9 @@ convenience.
 For the low-level API, the typical use case is
 
 - first parse a number into a [`Value`](`crate::value::Value`). For doing
-this, you have to specify the base, and maybe some constraint on the SI
-scales. See [`Value::new()`](`crate::value::Value::new\(\)`) and
-[`Value::new_with()`](`crate::value::Value::new_with\(\)`)
+  this, you have to specify the base, and maybe some constraint on the SI
+  scales. See [`Value::new()`](`crate::value::Value::new\(\)`) and
+  [`Value::new_with()`](`crate::value::Value::new_with\(\)`)
 
 - then display the `Value` either by yourself formatting the mantissa
   and prefix (implements the `fmt::Display` trait), or using the provided

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -27,8 +27,7 @@ if ! check_version $MSRV ; then
   exit 1
 fi
 
-FEATURES=()
-# check_version 1.74 && FEATURES+=(libm)
+FEATURES=(lossy-conversions)
 echo "Testing supported features: ${FEATURES[*]}"
 
 set -x

--- a/ci/test_full.sh
+++ b/ci/test_full.sh
@@ -3,7 +3,7 @@
 set -e
 
 CRATE=si-scale
-MSRV=1.74
+MSRV=1.78
 
 get_rust_version() {
   local array=($(rustc --version));

--- a/deny.toml
+++ b/deny.toml
@@ -17,14 +17,15 @@
 # this list would mean the nix crate, as well as any of its exclusive
 # dependencies not shared by any other crates, would be ignored, as the target
 # list here is effectively saying which targets you are building for.
+[graph]
 targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #{ triple = "x86_64-unknown-linux-musl" },
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+  # The triple can be any string, but only the target triples built in to
+  # rustc (as of 1.40) can be checked against actual config expressions
+  #{ triple = "x86_64-unknown-linux-musl" },
+  # You can also specify which target_features you promise are enabled for a
+  # particular target. target_features are currently not validated against
+  # the actual valid features supported by the target architecture.
+  #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
 ]
 
 # This section is considered when running `cargo deny check advisories`
@@ -38,7 +39,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+  #"RUSTSEC-0000-0000",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories
@@ -64,9 +65,9 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
+  "MIT",
+  "Apache-2.0",
+  #"Apache-2.0 WITH LLVM-exception",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -76,9 +77,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -97,8 +98,8 @@ exceptions = [
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]
@@ -111,7 +112,7 @@ ignore = false
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -130,28 +131,28 @@ wildcards = "allow"
 highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+  # Each entry the name of a crate and a version range. If version is
+  # not specified, all versions will be matched.
+  #{ name = "ansi_term", version = "=0.11.0" },
+  #
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+  #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/src/format.rs
+++ b/src/format.rs
@@ -157,7 +157,6 @@ fn separate_thousands_forward(input: &str, separator: char) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::format_value;
     use crate::value::Value;
 
     #[test]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -378,6 +378,7 @@ mod tests {
 
     /// Test that usize, u64, i64, isize work with helper functions.
     /// See https://github.com/graelo/si-scale/issues/4
+    #[cfg(feature = "lossy-conversions")]
     #[test]
     fn test_issue_4_usize_support() {
         let size: usize = 12_345_678;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -82,7 +82,7 @@ macro_rules! scale_fn {
         #[doc=$doc_arg]
         pub fn $name<F>(x: F) -> String
         where
-            F: Into<f64>,
+            F: $crate::value::IntoF64,
         {
             let value = $crate::value::Value::new_with(
                 x,
@@ -109,7 +109,7 @@ macro_rules! scale_fn {
         #[doc=$doc_arg]
         pub fn $name<F>(x: F) -> String
         where
-            F: Into<f64>,
+            F: $crate::value::IntoF64,
         {
             let value = $crate::value::Value::new_with(
                 x,
@@ -135,7 +135,7 @@ macro_rules! scale_fn {
         #[doc=$doc_arg]
         pub fn $name<F>(x: F) -> String
         where
-            F: Into<f64>,
+            F: $crate::value::IntoF64,
         {
             let value = $crate::value::Value::new_with(
                 x,
@@ -373,6 +373,31 @@ mod tests {
 
         let actual = format!("result is {}", seconds3(83.99999999999999e-9));
         let expected = "result is 84.000 ns";
+        assert_eq!(actual, expected);
+    }
+
+    /// Test that usize, u64, i64, isize work with helper functions.
+    /// See https://github.com/graelo/si-scale/issues/4
+    #[test]
+    fn test_issue_4_usize_support() {
+        let size: usize = 12_345_678;
+        let actual = format!("result is {}", bytes1(size));
+        let expected = "result is 12.3 MB";
+        assert_eq!(actual, expected);
+
+        let size: u64 = 1_000_000_000;
+        let actual = format!("result is {}", bytes1(size));
+        let expected = "result is 1.0 GB";
+        assert_eq!(actual, expected);
+
+        let size: i64 = -500_000;
+        let actual = format!("result is {}", bytes1(size));
+        let expected = "result is -500.0 kB";
+        assert_eq!(actual, expected);
+
+        let size: isize = 2048;
+        let actual = format!("result is {}", bibytes1(size));
+        let expected = "result is 2.0 kiB";
         assert_eq!(actual, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! Format value with units according to SI ([système international d'unités](https://en.wikipedia.org/wiki/International_System_of_Units)).
 //!
-//! Version requirement: _rustc 1.74+_
+//! Version requirement: _rustc 1.78+_
 //!
 //! ```toml
 //! [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,5 +472,5 @@ pub mod value;
 pub mod prelude {
     pub use crate::base::Base;
     pub use crate::prefix::{Constraint, Prefix};
-    pub use crate::value::Value;
+    pub use crate::value::{IntoF64, Value};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,16 @@
 //! assert_eq!(actual, expected);
 //! ```
 //!
+//! ## Features
+//!
+//! - **`lossy-conversions`**: enables support for `u64`, `i64`, `usize`, and
+//!   `isize`. These conversions may lose precision for values > 2^53.
+//!
+//! ```toml
+//! [dependencies]
+//! si-scale = { version = "0.2", features = ["lossy-conversions"] }
+//! ```
+//!
 //! ## Pre-defined helper functions
 //!
 //! The helper functions use the following naming convention:

--- a/src/value.rs
+++ b/src/value.rs
@@ -72,6 +72,9 @@ macro_rules! impl_into_f64_lossless {
     };
 }
 
+impl_into_f64_lossless!(u8, i8, u16, i16, u32, i32, f32, f64);
+
+#[cfg(feature = "lossy-conversions")]
 macro_rules! impl_into_f64_lossy {
     ($($t:ty),*) => {
         $(
@@ -85,7 +88,7 @@ macro_rules! impl_into_f64_lossy {
     };
 }
 
-impl_into_f64_lossless!(u8, i8, u16, i16, u32, i32, f32, f64);
+#[cfg(feature = "lossy-conversions")]
 impl_into_f64_lossy!(u64, i64, usize, isize);
 
 /// Defines the representation of the value.
@@ -337,12 +340,17 @@ impl_from_num_for_value!(u16);
 impl_from_num_for_value!(i16);
 impl_from_num_for_value!(u32);
 impl_from_num_for_value!(i32);
-impl_from_num_for_value!(u64);
-impl_from_num_for_value!(i64);
-impl_from_num_for_value!(usize);
-impl_from_num_for_value!(isize);
 impl_from_num_for_value!(f32);
 impl_from_num_for_value!(f64);
+
+#[cfg(feature = "lossy-conversions")]
+impl_from_num_for_value!(u64);
+#[cfg(feature = "lossy-conversions")]
+impl_from_num_for_value!(i64);
+#[cfg(feature = "lossy-conversions")]
+impl_from_num_for_value!(usize);
+#[cfg(feature = "lossy-conversions")]
+impl_from_num_for_value!(isize);
 
 #[cfg(test)]
 mod tests {

--- a/src/value.rs
+++ b/src/value.rs
@@ -54,6 +54,11 @@ use crate::prefix::Constraint;
 /// This trait enables uniform handling of all numeric types, including those
 /// like `u64`, `i64`, `usize`, and `isize` that don't implement `Into<f64>`
 /// because the conversion may be lossy.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot be converted to `f64`",
+    label = "this type doesn't implement `IntoF64`",
+    note = "for `u64`, `i64`, `usize`, or `isize`, enable the `lossy-conversions` feature"
+)]
 pub trait IntoF64 {
     /// Converts self to `f64`.
     fn into_f64(self) -> f64;


### PR DESCRIPTION
- Converting from i64, f64, isize, usize is lossy, so the user needs to use the new Cargo feature `lossy-conversions`.
- Bumping MSRV to 1.78 for the diagnostic that advertises this feature to work.

Fixes: #4 