### PR TITLE
chore(ci): bump actions and cleanup cargo metadata

### DIFF
--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -22,14 +22,14 @@ jobs:
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           # fetch-depth: ${{ github.event.pull_request.commits }}
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         continue-on-error: false
         with:
           path: |

--- a/.github/workflows/essentials.yml
+++ b/.github/workflows/essentials.yml
@@ -67,16 +67,6 @@ jobs:
           mv cargo-deny ~/.cargo/bin/
           cargo deny check
 
-      - name: Quality - cargo audit check
-        run: |
-          VERSION=$(curl -s https://api.github.com/repos/rustsec/rustsec/releases/latest | jq -r '.tag_name')
-          curl -sSfL "https://github.com/rustsec/rustsec/releases/download/${VERSION}/cargo-audit-x86_64-unknown-linux-musl-${VERSION#cargo-audit/}.tgz" | \
-            tar zx --no-anchored cargo-audit --strip-components=1
-          chmod +x cargo-audit
-          mv cargo-audit ~/.cargo/bin/
-          rm -rf ~/.cargo/advisory-db/
-          cargo audit --ignore RUSTSEC-2020-0071 # time-rs, but not used by chrono, see https://github.com/chronotope/chrono/issues/602
-
       - name: Quality - cargo outdated
         timeout-minutes: 20
         run: |

--- a/.github/workflows/large-scope.yml
+++ b/.github/workflows/large-scope.yml
@@ -22,10 +22,10 @@ jobs:
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         continue-on-error: false
         with:
           path: |
@@ -84,10 +84,10 @@ jobs:
           components: rustfmt, clippy
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Cache crates from crates.io
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         continue-on-error: false
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # convco needs all history to create the changelog
           fetch-depth: 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,20 +5,19 @@ edition = "2018"
 description = "Format values using the appropriate SI scale: seconds(1.3e-5) -> 13 µs"
 readme = "README.md"
 
-license = "MIT OR Apache-2.0"
-authors = ["graelo <graelo@graelo.cc>"]
-repository = "https://github.com/graelo/si-scale"
-homepage = "https://github.com/graelo/si-scale"
 documentation = "https://docs.rs/si-scale"
+homepage = "https://github.com/graelo/si-scale"
+repository = "https://github.com/graelo/si-scale"
+license = "MIT OR Apache-2.0"
 
-keywords = ["units", "pretty", "human", "number", "si-units"]
-categories = ["value-formatting", "science"]
+keywords = ["human", "number", "pretty", "si-units", "units"]
+categories = ["science", "value-formatting"]
 exclude = ["/.github"]
+
+[dependencies]
 
 [features]
 default = []
 ## Enable `IntoF64` for `u64`, `i64`, `usize`, and `isize`.
 ## These conversions may lose precision for values > 2^53.
 lossy-conversions = []
-
-[dependencies]


### PR DESCRIPTION
Update GitHub Actions to latest versions and clean up Cargo.toml metadata.

Bumps actions/checkout from v4 to v6, actions/cache from v4 to v5, and 
actions/download|upload-artifact. Also removes cargo-audit check as it's covered by 
cargo-pants. Cleans up Cargo.toml metadata formatting and reorders fields.

- Updated GitHub Actions versions
- Removed cargo-audit check (covered by cargo-pants)
- Cleaned up Cargo.toml metadata formatting