### PR TITLE
Add Renovate workflow

### DIFF
--- a/.github/poutine.yml
+++ b/.github/poutine.yml
@@ -7,4 +7,5 @@ skip:
       - pkg:githubactions/dorny/paths-filter
       - pkg:githubactions/zizmorcore/zizmor-action
       - pkg:githubactions/boostsecurityio/poutine-action
+      - pkg:githubactions/renovatebot/github-action
       - pkg:githubactions/taiki-e/install-action

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,41 @@
+# Runs Renovate to check for dependency updates.
+# Triggers daily at 19:00 UTC, or manually via workflow_dispatch.
+
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 19 * * *' # daily at 19:00 UTC
+
+permissions: {}
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    environment: renovate
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_TOKEN: ${{ steps.app-token.outputs.token }}
+        with:
+          configurationFile: renovate.json


### PR DESCRIPTION
Add the daily Renovate workflow that was missed in the initial hardening PR.
Authenticates via GitHub App token from the `renovate` environment, runs
daily at 19:00 UTC. Also adds `renovatebot/github-action` to the poutine
suppression list.

Requires `APP_CLIENT_ID` and `APP_PRIVATE_KEY` secrets in the `renovate`
environment (same setup as tmux-backup).