### PR TITLE
ci: apply matrix-job conventions to workflows

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-rust-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-platforms
 
 name: 'CI: Compatibility Matrix'
 
@@ -18,8 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-versions:
-    name: ubuntu-latest (${{ matrix.rust }})
+  test-rust-versions:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,8 +62,7 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-all-platforms:
-    name: ${{ matrix.target }}
+  test-platforms:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -19,14 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Checkout
@@ -47,7 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-stable-hash-${{ hashFiles('Cargo.toml') }}
 
       - name: Quality – cargo fmt
         run: |


### PR DESCRIPTION
Aligns workflow YAML with the playbook's matrix-job conventions so CI
check names stay readable and grep-friendly.

Matrix jobs in ci-compatibility-matrix.yml lose their custom name:
overrides, so GitHub auto-renders each variant as
test-rust-versions (1.78.0) / test-platforms (x86_64-unknown-linux-musl,
ubuntu-latest) — the job key stays visible in logs and check names. The
generic test-all-versions / test-all-platforms keys are renamed to
test-rust-versions / test-platforms to describe what each axis varies.

In ci-essentials.yml, the single-value rust: [stable] matrix is dropped
and "stable" is inlined into the toolchain field and cache key — no
behavior change, just less indirection.