### PR TITLE
ci: sync hardening conventions from github-actions-playbook

### DIFF
--- a/.github/workflows/_cargo-audit.yml
+++ b/.github/workflows/_cargo-audit.yml
@@ -29,25 +29,21 @@ jobs:
         continue-on-error: false
         with:
           path: |
-            ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-stable-audit-${{ hashFiles('Cargo.toml') }}
 
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@c070f87102a1c75b3183910f391c1cb887fe13c8 # v2.77.6
+        with:
+          tool: cargo-deny@0.19.6
+
       - name: Security – cargo deny
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION=$(gh api repos/EmbarkStudios/cargo-deny/releases/latest --jq '.tag_name')
-          curl -sSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${VERSION}/cargo-deny-${VERSION}-x86_64-unknown-linux-musl.tar.gz" | \
-            tar zx --no-anchored cargo-deny --strip-components=1
-          chmod +x cargo-deny
-          mv cargo-deny ~/.cargo/bin/
-          cargo deny check
+        run: cargo deny --locked check
 
       - name: Security – cargo pants
         run: |
-          cargo install --locked cargo-pants || true
+          cargo install --locked cargo-pants || command -v cargo-pants
           cargo pants

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ contains(github.ref, '-') }}
         run: |
           gh release create "${TAG_NAME}" \
+            --prerelease="${IS_PRERELEASE}" \
             --title "${TAG_NAME}" \
             --notes-file CHANGELOG.md

--- a/.github/workflows/schedule-renovate.yml
+++ b/.github/workflows/schedule-renovate.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          permission-statuses: write
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Apply four conventions from the github-actions-playbook to the workflows here.

In _cargo-audit.yml, install cargo-deny via taiki-e/install-action (prebuilt
binary, pinned to 0.19.6) instead of the hand-rolled gh api + curl + tar
script; drop ~/.cargo/bin/ from the cache paths now that nothing CI-installed
lands there; pass --locked as a top-level flag (cargo deny --locked check) per
§13; and replace the cargo-pants install fallback `|| true` with
`|| command -v cargo-pants` so real install failures surface at the install
step rather than as a misleading "command not found" later.

In schedule-renovate.yml, scope the App token with explicit permission-<name>
inputs (contents, issues, pull-requests, workflows, statuses) so the token no
longer carries the App installation's full permission set — addresses zizmor's
github-app finding.

In release.yml, mark tags containing '-' (v1.2.3-rc.1, -alpha.2, …) as GitHub
pre-releases via --prerelease="${IS_PRERELEASE}" with IS_PRERELEASE computed
from contains(github.ref, '-'). The tag pattern already accepts these tags;
this stops them from publishing as "latest".