### PR TITLE
ci: change automerge strategy to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
-  "automergeStrategy": "merge-commit",
+  "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Switch Renovate automerge strategy from `merge-commit` to `squash`. Keeps the history cleaner by avoiding merge bubbles for dependency updates.